### PR TITLE
Support for Python 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/
 
 # Python byte code
+*.pyc
 __pycache__/
 
 # Test cached data

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 language: python
 
 python:
+  - '3.5'
   - '3.6'
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ deps:
 
 build:
 	@echo "Making distribution..."
-	rm dist/*
+	rm -f dist/*
 	python setup.py sdist
 	@echo "Done"
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Collection of utils for Quizlet flash cards
 
 Tested on:
 
-- Python 3.6.1
-- macOS
+- macOS / Python 3.6.1
+- Ubuntu 14.04 / Python 3.5.3
 
 To install Python requirements (virtualenv is recommended):
 

--- a/quizler/lib.py
+++ b/quizler/lib.py
@@ -16,12 +16,12 @@ def get_api_envs():
 
 def api_call(end_point, client_id, user_id):
     """Call given API end_point with API keys."""
-    url = f'https://api.quizlet.com/2.0/users/{user_id}/{end_point}'
+    url = 'https://api.quizlet.com/2.0/users/{}/{}'.format(user_id, end_point)
     params = {'client_id': client_id}
     response = requests.get(url, params)
     if response.status_code != 200:
         raise ValueError(
-            f'Unknown end point, server returns {response.status_code}'
+            'Unknown end point, server returns {}'.format(response.status_code)
         )
     else:
         return response.json()

--- a/quizler/models.py
+++ b/quizler/models.py
@@ -23,10 +23,10 @@ class WordSet:
 
     def __init__(self, raw_data):
         try:
-            self.set_id: int = raw_data['id']
-            self.title: str = raw_data['title']
+            self.set_id = raw_data['id']
+            self.title = raw_data['title']
             # ToDo: separate abstraction for Terms
-            self.terms: List[Dict] = raw_data['terms']
+            self.terms = raw_data['terms']
         except KeyError:
             raise ValueError('Unexpected set json structure')
 
@@ -50,6 +50,6 @@ class WordSet:
         ))
 
     def __str__(self):
-        return f'{self.title}'
+        return '{}'.format(self.title)
 
     __repr__ = __str__

--- a/quizler/utils.py
+++ b/quizler/utils.py
@@ -19,9 +19,9 @@ def print_user_sets(wordsets: List[WordSet]):
     if not wordsets:
         print('No sets found')
     else:
-        print(f'Found sets: {len(wordsets)}')
+        print('Found sets: {}'.format(len(wordsets)))
         for wordset in wordsets:
-            print(f'    {wordset}')
+            print('    {}'.format(wordset))
 
 
 def get_common_terms(*api_envs) -> List[Tuple[str, str, Set[str]]]:
@@ -43,9 +43,9 @@ def print_common_terms(common_terms: List[Tuple[str, str, Set[str]]]):
     else:
         for set_pair in common_terms:
             set1, set2, terms = set_pair
-            print(f'{set1} and {set2} have in common:')
+            print('{} and {} have in common:'.format(set1, set2))
             for term in terms:
-                print(f'    {term}')
+                print('    {}'.format(term))
 
 
 def apply_regex(pattern, repl, set_name, *api_envs):

--- a/tests/quizler/test_main.py
+++ b/tests/quizler/test_main.py
@@ -41,22 +41,22 @@ class TestCreateParser(unittest.TestCase):
 @mock_envs(CLIENT_ID='client_id', USER_ID='user_id')
 class TestMain(unittest.TestCase):
 
-    @mock.patch('quizler.main.get_common_terms')
     @mock.patch('quizler.main.print_common_terms')
+    @mock.patch('quizler.main.get_common_terms')
     @mock_argv('common')
     def test_common(self, mock_get_common_terms, mock_print_common_terms):
         main()
-        mock_get_common_terms.assert_called_once()
-        mock_print_common_terms.assert_called_once()
+        mock_get_common_terms.assert_called_once_with('client_id', 'user_id')
+        mock_print_common_terms.assert_called_once_with(mock.ANY)
 
     @mock.patch('quizler.main.get_user_sets')
     @mock_argv('sets')
     def test_sets(self, mock_get_user_sets):
         main()
-        mock_get_user_sets.assert_called_once()
+        mock_get_user_sets.assert_called_once_with('client_id', 'user_id')
 
     @mock.patch('quizler.main.apply_regex')
     @mock_argv('apply', 'pattern', 'repl', 'set_name')
     def test_apply(self, mock_apply_regex):
         main()
-        mock_apply_regex.assert_called_once()
+        mock_apply_regex.assert_called_once_with('pattern', 'repl', 'set_name', 'client_id', 'user_id')


### PR DESCRIPTION
Python 3.6 isn't yet officially supported on Ubuntu and although it's pretty easy to get an interpreter already, getting pip to work nicely with this version [is a pain](https://stackoverflow.com/questions/41720578/modulenotfounderror-in-tracebacks-with-python3-6-on-linux).

Your code was nicer before, so I'm not proud of this move :/ But supporting Python 3.5 will allow me and others to use your tool on Ubuntu.

(FYI I'm planning to extend it with a command for resetting the score/stats of a specific term. Useful when you know that you have forgotten this term and you want to force Quizlet to ask it again.