### PR TITLE
Fixes #25 - test data generation

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,7 @@
 [MESSAGES CONTROL]
-disable=too-few-public-methods
+disable=too-few-public-methods,
+ duplicate-code,
+ too-many-arguments
 
 [TYPECHECK]
 # False positives on tests accessing sys.stdout's methods:

--- a/quizler/models.py
+++ b/quizler/models.py
@@ -1,33 +1,62 @@
 """OOP models for Quizlet terms abstractions."""
 
-# ToDo: base class for Term and WordSet
+
 class Term:
     """Quizlet term abstraction."""
 
-    def __init__(self, raw_data):
+    def __init__(self, definition, term_id, image, rank, term):
+        self.definition = definition
+        # pylint: disable=invalid-name
+        self.id = term_id
+        # pylint: enable=invalid-name
+        self.image = image
+        self.rank = rank
+        self.term = term
+
+    @staticmethod
+    def from_dict(raw_data):
+        """Create Term from raw dictionary data."""
         try:
-            self.definition = raw_data['definition']
-            # pylint: disable=invalid-name
-            self.id = raw_data['id']
-            # pylint: enable=invalid-name
-            self.image = raw_data['image']
-            self.rank = raw_data['rank']
-            self.term = raw_data['term']
+            definition = raw_data['definition']
+            term_id = raw_data['id']
+            image = raw_data['image']
+            rank = raw_data['rank']
+            term = raw_data['term']
+            return Term(definition, term_id, image, rank, term)
         except KeyError:
             raise ValueError('Unexpected term json structure')
+
+    def to_dict(self):
+        """Convert Term into raw dictionary data."""
+        return {
+            'definition': self.definition,
+            'id': self.id,
+            'image': self.image,
+            'rank': self.rank,
+            'term': self.term
+        }
+
+    def __eq__(self, other):
+        if not isinstance(other, Term):
+            raise ValueError
+        return all((
+            self.definition == other.definition,
+            self.id == other.id,
+            self.image == other.image,
+            self.rank == other.rank,
+            self.term == other.term
+        ))
 
 
 class WordSet:
     """Quizlet set of terms and descriptions abstraction."""
 
-    def __init__(self, raw_data):
-        try:
-            self.set_id = raw_data['id']
-            self.title = raw_data['title']
-            # ToDo: separate abstraction for Terms
-            self.terms = raw_data['terms']
-        except KeyError:
-            raise ValueError('Unexpected set json structure')
+    def __init__(self, set_id, title, terms):
+        # pylint: disable=invalid-name
+        self.id = set_id
+        # pylint: enable=invalid-name
+        self.title = title
+        self.terms = terms
 
     def has_common(self, other):
         """Return set of common words between two word sets."""
@@ -38,12 +67,30 @@ class WordSet:
     @property
     def term_set(self):
         """Set of all terms in WordSet."""
-        return {term['term'] for term in self.terms}
+        return {term.term for term in self.terms}
+
+    @staticmethod
+    def from_dict(raw_data):
+        """Create WordSet from raw dictionary data."""
+        try:
+            set_id = raw_data['id']
+            title = raw_data['title']
+            terms = [Term.from_dict(term) for term in raw_data['terms']]
+            return WordSet(set_id, title, terms)
+        except KeyError:
+            raise ValueError('Unexpected set json structure')
+
+    def to_dict(self):
+        """Convert WordSet into raw dictionary data."""
+        return {
+            'id': self.id,
+            'title': self.title,
+            'terms': [term.to_dict() for term in self.terms]
+        }
 
     def __eq__(self, other):
-        # ToDo: introduce better solution
         return all((
-            self.set_id == other.set_id,
+            self.id == other.id,
             self.title == other.title,
             self.terms == other.terms
         ))
@@ -51,4 +98,5 @@ class WordSet:
     def __str__(self):
         return '{}'.format(self.title)
 
-    __repr__ = __str__
+    def __repr__(self):
+        return 'WordSet(id={}, title={})'.format(self.id, self.title)

--- a/quizler/utils.py
+++ b/quizler/utils.py
@@ -13,7 +13,7 @@ def get_user_sets(*api_envs):
     # pylint: disable=no-value-for-parameter
     data = api_call('sets', *api_envs)
     # pylint: enable=no-value-for-parameter
-    return [WordSet(wordset) for wordset in data]
+    return [WordSet.from_dict(wordset) for wordset in data]
 
 
 def print_user_sets(wordsets: List[WordSet]):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.18.4
 pylint==1.8.1
 pytest==3.3.1
+factory-boy==2.9.2

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,28 @@
+# pylint: disable=missing-docstring
+
+"""Factories for generating test data."""
+
+import factory
+
+from quizler import models
+
+
+class TermFactory(factory.Factory):
+    class Meta:
+        model = models.Term
+
+    definition = factory.LazyAttribute(
+        lambda obj: 'definition{}'.format(obj.term_id))
+    term_id = factory.Sequence(lambda n: n)
+    image = None
+    rank = 0
+    term = factory.LazyAttribute(lambda obj: 'term{}'.format(obj.term_id))
+
+
+class WordSetFactory(factory.Factory):
+    class Meta:
+        model = models.WordSet
+
+    set_id = factory.Sequence(lambda n: n)
+    title = factory.LazyAttribute(lambda obj: 'title{}'.format(obj.set_id))
+    terms = []

--- a/tests/quizler/test_models.py
+++ b/tests/quizler/test_models.py
@@ -2,12 +2,13 @@
 
 import unittest
 
-from quizler.models import WordSet, Term
+from quizler.models import Term, WordSet
+from tests.factories import TermFactory, WordSetFactory
 
 
 class TestTerm(unittest.TestCase):
 
-    def test_correct_init(self):
+    def test_from_dict(self):
         raw_data = {
             'definition': 'term definition',
             'id': 12345,
@@ -15,52 +16,125 @@ class TestTerm(unittest.TestCase):
             'rank': 0,
             'term': 'term'
         }
-        term = Term(raw_data)
-        self.assertEqual(term.definition, 'term definition')
-        self.assertEqual(term.id, 12345)
-        self.assertEqual(term.image, None)
-        self.assertEqual(term.rank, 0)
-        self.assertEqual(term.term, 'term')
+        term = Term.from_dict(raw_data)
+        assert term.definition == 'term definition'
+        assert term.id == 12345
+        assert term.image is None
+        assert term.rank == 0
+        assert term.term == 'term'
 
     def test_wrong_term_json_structure(self):
         with self.assertRaises(ValueError):
-            Term({'some data': '142% unexpected'})
+            Term.from_dict({'some data': '142% unexpected'})
+
+    def test_correct_init(self):
+        term = Term('definition', 1, None, 0, 'term')
+        assert term.definition == 'definition'
+        assert term.id == 1
+        assert term.image is None
+        assert term.term == 'term'
+
+    def test_to_dict(self):
+        term = Term('definition1', 1, None, 1, 'term1')
+        assert term.to_dict() == {
+            'definition': 'definition1',
+            'id': 1,
+            'image': None,
+            'rank': 1,
+            'term': 'term1'
+        }
+
+    def test_equal_terms(self):
+        term0 = Term('definition', 0, None, 0, 'term')
+        term1 = Term('definition', 0, None, 0, 'term')
+        assert term0 == term1
+
+    def test_unequal_terms(self):
+        term0 = Term('definition0', 0, None, 0, 'term0')
+        term1 = Term('definition1', 1, None, 0, 'term1')
+        assert term0 != term1
 
 
 class TestWordSet(unittest.TestCase):
 
-    def setUp(self):
-        self.word_set_1 = WordSet({
-            'id': 0,
-            'title': 'WordSet1',
-            'terms': [{'term': 'term1'},
-                      {'term': 'term2'}]
-        })
-        self.word_set_2 = WordSet({
-            'id': 1,
-            'title': 'WordSet2',
-            'terms': [{'term': 'term2'},
-                      {'term': 'term3'}]
-        })
+    @classmethod
+    def setUpClass(cls):
+        cls.term0 = TermFactory()
+        cls.term1 = TermFactory()
+        cls.term2 = TermFactory()
+        cls.word_set_0 = WordSetFactory(terms=[cls.term0, cls.term1])
+        cls.word_set_1 = WordSetFactory(terms=[cls.term1, cls.term2])
 
     def test_terms_set(self):
-        self.assertSetEqual(self.word_set_1.term_set, {'term1', 'term2'})
-        self.assertSetEqual(self.word_set_2.term_set, {'term2', 'term3'})
+        assert self.word_set_0.term_set == {self.term0.term, self.term1.term}
+        assert self.word_set_1.term_set == {self.term1.term, self.term2.term}
 
     def test_has_common(self):
-        self.assertSetEqual(
-            self.word_set_1.has_common(self.word_set_2),
-            {'term2'}
-        )
+        assert self.word_set_0.has_common(self.word_set_1) == {self.term1.term}
 
     def test_has_common_wrong_type(self):
         with self.assertRaises(ValueError):
-            self.word_set_1.has_common([1, 2, 3])
+            self.word_set_0.has_common([1, 2, 3])
+
+    def test_from_dict(self):
+        raw_data = {
+            'id': 0,
+            'title': 'title0',
+            'terms': [
+                {
+                    'definition': 'definition0',
+                    'id': 0,
+                    'image': None,
+                    'rank': 0,
+                    'term': 'term0'
+                }
+            ]
+        }
+        wordset = WordSet.from_dict(raw_data)
+        assert wordset.id == 0
+        assert wordset.title == 'title0'
+        assert wordset.terms == [Term('definition0', 0, None, 0, 'term0')]
+
+    def test_to_dict(self):
+        wordset = WordSet(0, 'title0', [Term('def0', 0, None, 0, 'term0')])
+        assert wordset.to_dict() == {
+            'id': 0,
+            'title': 'title0',
+            'terms': [
+                {
+                    'definition': 'def0',
+                    'id': 0,
+                    'image': None,
+                    'rank': 0,
+                    'term': 'term0'
+                }
+            ]
+        }
+
+    def test_equal_wordsets(self):
+        term = TermFactory()
+        wordset0 = WordSet(0, 'title', terms=[term])
+        wordset1 = WordSet(0, 'title', terms=[term])
+        assert wordset0 == wordset1
+
+    def test_unequal_wordsets(self):
+        wordset0 = WordSet(0, 'title0', [])
+        wordset1 = WordSet(1, 'title1', [])
+        assert wordset0 != wordset1
+
+    def test_equal_wordsets_with_different_terms(self):
+        term0 = TermFactory()
+        term1 = TermFactory()
+        wordset0 = WordSet(0, 'title', terms=[term0])
+        wordset1 = WordSet(0, 'title', terms=[term1])
+        assert wordset0 != wordset1
 
     def test_repr(self):
-        self.assertEqual(repr(self.word_set_1), 'WordSet1')
-        self.assertEqual(repr(self.word_set_2), 'WordSet2')
+        assert repr(self.word_set_0) == 'WordSet(id={}, title={})'.format(
+            self.word_set_0.id, self.word_set_0.title)
+        assert repr(self.word_set_1) == 'WordSet(id={}, title={})'.format(
+            self.word_set_1.id, self.word_set_1.title)
 
     def test_str(self):
-        self.assertEqual(str(self.word_set_1), 'WordSet1')
-        self.assertEqual(str(self.word_set_2), 'WordSet2')
+        assert str(self.word_set_0) == self.word_set_0.title
+        assert str(self.word_set_1) == self.word_set_1.title


### PR DESCRIPTION
I planned to refactor test data creation with `factory_boy` to simplify tests. Not sure if I succeed, but I hope they're at least more readable. Maybe it's an overkill so, please, give your opinion. Should be easy to revert this part.

I also refactored `WordSet` to rely on unused (before) `Term` model and added `to_dict` and `from_dict` helper methods to both models. Now classes have simple standard constructors which are in turn very helpful for testing. One can easily parse data from Quizlet with `from_dict` class method.

Sorry for the wall of code! I'll split next time.